### PR TITLE
Fix

### DIFF
--- a/German/main/SecurityCenter.apk/res/values-de/strings.xml
+++ b/German/main/SecurityCenter.apk/res/values-de/strings.xml
@@ -501,7 +501,7 @@ Sie verlieren keine Appdaten."</string>
   <string name="cmcc_app_check_dialog_title">System repariert</string>
   <string name="confirmSecondSpacePassword">Passwort Zweitprofil bestätigen</string>
   <string name="confirm_bind_xiaomi_account_dialog_title">Mi Konto hinzufügen</string>
-  <string name="confirm_fingerprint_msg">Fingerabdruck virifizieren</string>
+  <string name="confirm_fingerprint_msg">Fingerabdruck verifizieren</string>
   <string name="confirm_prompt_all_permission">Nach Berechtigungen für alle Apps fragen?</string>
   <string name="confirm_reject_all_permission">Alle Apps daran hindern, diese Funktion zu nutzen?</string>
   <string name="connect_internet_by_mobiledata">Mobile Datenverbindung</string>

--- a/German/main/Settings.apk/res/values-de/strings.xml
+++ b/German/main/Settings.apk/res/values-de/strings.xml
@@ -1899,7 +1899,7 @@ Wenn es so bleibt, muss die App evtl. deinstalliert werden, um die Akkuleistung 
   <string name="display_auto_rotate_stay_in_portrait">Hochformat fixieren</string>
   <string name="display_auto_rotate_title">Bildschirminhalt drehen</string>
   <string name="display_category_title">Bildschirm</string>
-  <string name="display_cutout_emulation">Display mit Ausschnitt simulieren</string>
+  <string name="display_cutout_emulation">Display mit Notch simulieren</string>
   <string name="display_cutout_emulation_keywords">displayausschnitt, notch</string>
   <string name="display_cutout_emulation_none">Nichts</string>
   <string name="display_dashboard_summary">Hintergrund, schlafen, Schriftgröße</string>


### PR DESCRIPTION
"Fingerabdruck virifizieren" zu "Fingerabdruck verifizieren"
Und ändern von "Display mit Ausschnitt" zu "Display mit Notch" - sehr optional, klingt bloß besser und kenne niemanden der den Begriff der "Notch" heutzutage, insbesondere nach den iPhones, nicht kennt.